### PR TITLE
feat: build and publish @intrig/common

### DIFF
--- a/app/intrig/src/app/app.module.ts
+++ b/app/intrig/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { CliModule } from './cli/cli.module';
 import { DiscoveryModule } from './discovery/discovery.module';
 import { DeamonModule } from './deamon/deamon.module';
-import {CommonModule} from "common";
+import {CommonModule} from "@intrig/common";
 import {ConfigModule} from "@nestjs/config";
 import configuration from "./config/configuration";
 

--- a/app/intrig/src/app/cli/cli.module.ts
+++ b/app/intrig/src/app/cli/cli.module.ts
@@ -5,7 +5,7 @@ import {GenerateCommand} from "./commands/generate.command";
 import {InitCommand} from "./commands/init.command";
 import {SyncCommand} from "./commands/sync.command";
 import {SourcesCommand} from "./commands/sources.command";
-import {CommonModule, GeneratorBinding} from "common";
+import {CommonModule, GeneratorBinding} from "@intrig/common";
 import {DiscoveryModule} from "../discovery/discovery.module";
 import {HttpModule} from "@nestjs/axios";
 import {GENERATORS} from "./tokens";

--- a/app/intrig/src/app/cli/commands/init.command.ts
+++ b/app/intrig/src/app/cli/commands/init.command.ts
@@ -6,7 +6,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as fsx from 'fs-extra'
 import {GENERATORS} from "../tokens";
-import {GeneratorCli, IntrigConfig} from "common";
+import {GeneratorCli, IntrigConfig} from "@intrig/common";
 import {PackageJson} from "nx/src/utils/package-json";
 
 @Command({name: "init", description: "Initialize Intrig"})

--- a/app/intrig/src/app/cli/commands/postbuild.command.ts
+++ b/app/intrig/src/app/cli/commands/postbuild.command.ts
@@ -2,7 +2,7 @@ import {Command, CommandRunner} from "nest-commander";
 import {ProcessManagerService} from "../process-manager.service";
 import {Inject, Logger} from "@nestjs/common";
 import {GENERATORS} from "../tokens";
-import {GeneratorCli} from "common";
+import {GeneratorCli} from "@intrig/common";
 import {PackageJson} from "nx/src/utils/package-json";
 import * as fsx from "fs-extra";
 import path from "path";

--- a/app/intrig/src/app/cli/commands/prebuild.command.ts
+++ b/app/intrig/src/app/cli/commands/prebuild.command.ts
@@ -2,7 +2,7 @@ import {Command, CommandRunner} from "nest-commander";
 import {ProcessManagerService} from "../process-manager.service";
 import {Inject, Logger} from "@nestjs/common";
 import {GENERATORS} from "../tokens";
-import {GeneratorCli} from "common";
+import {GeneratorCli} from "@intrig/common";
 import {PackageJson} from "nx/src/utils/package-json";
 import * as fsx from "fs-extra";
 import path from "path";

--- a/app/intrig/src/app/cli/commands/search.command.ts
+++ b/app/intrig/src/app/cli/commands/search.command.ts
@@ -1,7 +1,7 @@
 import {Command, CommandRunner} from "nest-commander";
 import {HttpService} from "@nestjs/axios";
 import {lastValueFrom} from "rxjs";
-import {Page, ResourceDescriptor} from "common";
+import {Page, ResourceDescriptor} from "@intrig/common";
 import inquirer from "inquirer";
 import {ProcessManagerService} from "../process-manager.service";
 import chalk from "chalk";

--- a/app/intrig/src/app/deamon/controllers/data-search.controller.ts
+++ b/app/intrig/src/app/deamon/controllers/data-search.controller.ts
@@ -1,6 +1,6 @@
 import {Controller, Get, Query, Param, NotFoundException, UsePipes, ValidationPipe} from '@nestjs/common';
 import {ApiExtraModels, ApiOperation, ApiResponse, getSchemaPath} from '@nestjs/swagger';
-import {Page, ResourceDescriptor, RestDocumentation, SchemaDocumentation} from "common";
+import {Page, ResourceDescriptor, RestDocumentation, SchemaDocumentation} from "@intrig/common";
 import {DataSearchService} from "../services/data-search.service";
 import {SourceStats} from "../models/source-stats";
 import {SearchQuery} from "../models/search-query";

--- a/app/intrig/src/app/deamon/controllers/operations.controller.ts
+++ b/app/intrig/src/app/deamon/controllers/operations.controller.ts
@@ -7,7 +7,7 @@ import {
   SyncDoneEventDto,
   SyncEventContext,
   SyncStatusEventDto
-} from "common";
+} from "@intrig/common";
 import {Subject} from "rxjs";
 
 @ApiTags('Operations')

--- a/app/intrig/src/app/deamon/controllers/sources.controller.ts
+++ b/app/intrig/src/app/deamon/controllers/sources.controller.ts
@@ -1,7 +1,7 @@
 import {Body, Controller, Delete, Get, Logger, Param, Post} from '@nestjs/common';
 import {OpenapiService} from "../services/openapi.service";
-import {IntrigSourceConfig} from "common";
-import type {IIntrigSourceConfig} from "common";
+import {IntrigSourceConfig} from "@intrig/common";
+import type {IIntrigSourceConfig} from "@intrig/common";
 import {IntrigConfigService} from "../services/intrig-config.service";
 import {ApiBody, ApiExtraModels, ApiResponse, ApiTags} from "@nestjs/swagger";
 

--- a/app/intrig/src/app/deamon/deamon.module.ts
+++ b/app/intrig/src/app/deamon/deamon.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { SourcesController } from './controllers/sources.controller';
-import { CommonModule } from 'common';
+import { CommonModule } from '@intrig/common';
 import { IntrigConfigService } from './services/intrig-config.service';
 import { OpenapiService } from './services/openapi.service';
 import { OperationsController } from './controllers/operations.controller';

--- a/app/intrig/src/app/deamon/generator/generator.module.ts
+++ b/app/intrig/src/app/deamon/generator/generator.module.ts
@@ -2,7 +2,7 @@ import {DynamicModule, Module} from '@nestjs/common';
 import {IntrigConfigService} from "../services/intrig-config.service";
 // import {ReactBindingService} from "@intrig/react-binding";
 // import {IntrigNextBindingService} from "@intrig/next-binding";
-import {GeneratorBinding} from "common";
+import {GeneratorBinding} from "@intrig/common";
 import {loadDynamicModules} from "../../loadDynamicModules";
 
 @Module({})

--- a/app/intrig/src/app/deamon/services/data-search.service.ts
+++ b/app/intrig/src/app/deamon/services/data-search.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import {GeneratorBinding, Page, ResourceDescriptor, RestData} from "common";
+import {GeneratorBinding, Page, ResourceDescriptor, RestData} from "@intrig/common";
 import {SearchService} from "./search.service";
 
 @Injectable()

--- a/app/intrig/src/app/deamon/services/intrig-config.service.ts
+++ b/app/intrig/src/app/deamon/services/intrig-config.service.ts
@@ -1,7 +1,7 @@
 import {Injectable, Logger} from '@nestjs/common';
 import {join} from "path";
 import {readFileSync, writeFileSync} from "fs";
-import {IntrigConfig, IntrigSourceConfig} from "common";
+import {IntrigConfig, IntrigSourceConfig} from "@intrig/common";
 import {ConfigService} from "@nestjs/config";
 
 @Injectable()

--- a/app/intrig/src/app/deamon/services/openapi.service.ts
+++ b/app/intrig/src/app/deamon/services/openapi.service.ts
@@ -1,6 +1,6 @@
 import {Injectable, Logger} from '@nestjs/common';
 import {HttpService} from "@nestjs/axios";
-import {IntrigSourceConfig} from "common";
+import {IntrigSourceConfig} from "@intrig/common";
 import {lastValueFrom} from "rxjs";
 import {load as yamlLoad} from "js-yaml";
 

--- a/app/intrig/src/app/deamon/services/operations.service.ts
+++ b/app/intrig/src/app/deamon/services/operations.service.ts
@@ -5,9 +5,9 @@ import {
   ResourceDescriptor, RestData, Schema,
   SyncEventContext,
   WithStatus
-} from "common";
-import type {IntrigConfig} from "common";
-import type {GenerateEventContext, IIntrigSourceConfig} from "common";
+} from "@intrig/common";
+import type {IntrigConfig} from "@intrig/common";
+import type {GenerateEventContext, IIntrigSourceConfig} from "@intrig/common";
 import {IntrigConfigService} from "./intrig-config.service";
 import * as path from "path";
 import * as fs from 'fs-extra'

--- a/app/intrig/src/app/deamon/services/search.service.ts
+++ b/app/intrig/src/app/deamon/services/search.service.ts
@@ -1,6 +1,6 @@
 import {Injectable, OnModuleInit} from '@nestjs/common';
 import MiniSearch from 'minisearch';
-import {isRestDescriptor, isSchemaDescriptor, ResourceDescriptor, RestData, Schema} from 'common';
+import {isRestDescriptor, isSchemaDescriptor, ResourceDescriptor, RestData, Schema} from '@intrig/common';
 import {IntrigConfigService} from "./intrig-config.service";
 import {IntrigOpenapiService} from "openapi-source";
 import {SourceStats} from "../models/source-stats";

--- a/app/intrig/src/app/loadDynamicModules.ts
+++ b/app/intrig/src/app/loadDynamicModules.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import pacote from 'pacote';
 import npa from 'npm-package-arg';
 import { Logger } from '@nestjs/common';
-import { IntrigConfig, Plugin } from 'common';
+import { IntrigConfig, Plugin } from '@intrig/common';
 import { createJiti } from 'jiti';
 
 const logger = new Logger('loadDynamicModules');

--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "common",
+  "name": "@intrig/common",
   "version": "0.0.1",
-  "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "type": "module",
+  "main": "./src/index.js",
+  "module": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "development": "./src/index.ts",
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/lib/common/project.json
+++ b/lib/common/project.json
@@ -1,9 +1,28 @@
 {
-  "name": "common",
+  "name": "@intrig/common",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "lib/common/src",
   "projectType": "library",
   "tags": [],
   "// targets": "to see all targets run: nx show project common --web",
-  "targets": {}
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/lib/common",
+        "tsConfig": "lib/common/tsconfig.lib.json",
+        "packageJson": "lib/common/package.json",
+        "main": "lib/common/src/index.ts",
+        "assets": ["lib/common/README.md"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/js:release-publish",
+      "options": {
+        "packageRoot": "dist/lib/common"
+      },
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/lib/common/tsconfig.lib.json
+++ b/lib/common/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",

--- a/lib/next-binding/src/lib/cli/next-cli.service.ts
+++ b/lib/next-binding/src/lib/cli/next-cli.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {GeneratorCli, PackageManagerService} from "common";
+import {GeneratorCli, PackageManagerService} from "@intrig/common";
 import { PackageJson } from 'nx/src/utils/package-json';
 import {ConfigService} from "@nestjs/config";
 import path from "path";

--- a/lib/next-binding/src/lib/next-binding.service.ts
+++ b/lib/next-binding/src/lib/next-binding.service.ts
@@ -5,7 +5,7 @@ import {
   ResourceDescriptor,
   RestData, RestDocumentation, RestOptions, Schema, SchemaDocumentation,
   SourceManagementService, Tab
-} from "common";
+} from "@intrig/common";
 import { networkStateTemplate } from './templates/network-state.template';
 import { providerTemplate } from './templates/provider.template';
 import { indexTemplate } from './templates/index.template';

--- a/lib/next-binding/src/lib/plugin.ts
+++ b/lib/next-binding/src/lib/plugin.ts
@@ -1,4 +1,4 @@
-import {Plugin} from "common";
+import {Plugin} from "@intrig/common";
 import {NextBindingModule} from "./next-binding.module";
 import {IntrigNextBindingService} from "./next-binding.service";
 import {NextCliModule} from "./cli/next-cli.module";

--- a/lib/next-binding/src/lib/templates/context.template.ts
+++ b/lib/next-binding/src/lib/templates/context.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function contextTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/docs/react-hook.ts
+++ b/lib/next-binding/src/lib/templates/docs/react-hook.ts
@@ -1,4 +1,4 @@
-import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from 'common'
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from '@intrig/common'
 
 export function reactHookDocs(descriptor: ResourceDescriptor<RestData>) {
   const md = mdLiteral('react-hook.md')

--- a/lib/next-binding/src/lib/templates/extra.template.ts
+++ b/lib/next-binding/src/lib/templates/extra.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function extraTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/index.template.ts
+++ b/lib/next-binding/src/lib/templates/index.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function indexTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/intrig-layout.template.ts
+++ b/lib/next-binding/src/lib/templates/intrig-layout.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function intrigLayoutTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/intrigMiddleware.template.ts
+++ b/lib/next-binding/src/lib/templates/intrigMiddleware.template.ts
@@ -1,4 +1,4 @@
-import { typescript } from 'common';
+import { typescript } from '@intrig/common';
 import * as path from 'path'
 
 export function intrigMiddlewareTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/logger.template.ts
+++ b/lib/next-binding/src/lib/templates/logger.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function loggerTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/media-type-utils.template.ts
+++ b/lib/next-binding/src/lib/templates/media-type-utils.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from "path";
 
 export function mediaTypeUtilsTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/network-state.template.ts
+++ b/lib/next-binding/src/lib/templates/network-state.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function networkStateTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/packageJson.template.ts
+++ b/lib/next-binding/src/lib/templates/packageJson.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 
 export function packageJsonTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/provider.template.ts
+++ b/lib/next-binding/src/lib/templates/provider.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function providerTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/source/controller/method/clientIndex.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/clientIndex.template.ts
@@ -1,7 +1,7 @@
 import {
   camelCase, ResourceDescriptor, RestData,
   typescript
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path'
 import * as _ from "lodash";
 

--- a/lib/next-binding/src/lib/templates/source/controller/method/download.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/download.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase,
   ResourceDescriptor, RestData,
   typescript
-} from 'common';
+} from '@intrig/common';
 import path from 'path';
 
 export function downloadHookTemplate(

--- a/lib/next-binding/src/lib/templates/source/controller/method/params.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/params.template.ts
@@ -1,4 +1,4 @@
-import {camelCase, decodeVariables, pascalCase, ResourceDescriptor, RestData, typescript} from "common";
+import {camelCase, decodeVariables, pascalCase, ResourceDescriptor, RestData, typescript} from "@intrig/common";
 import * as path from "path";
 
 export function paramsTemplate(

--- a/lib/next-binding/src/lib/templates/source/controller/method/requestHook.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/requestHook.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase, ResourceDescriptor, RestData,
   typescript,
   Variable
-} from 'common';
+} from '@intrig/common';
 import path from 'path';
 
 function extractHookShapeAndOptionsShape(response: string | undefined, requestBody: string | undefined, imports: Set<string>) {

--- a/lib/next-binding/src/lib/templates/source/controller/method/requestMethod.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/requestMethod.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase,
   ResourceDescriptor, RestData,
   typescript, Variable
-} from 'common';
+} from '@intrig/common';
 import path from 'path';
 
 function extractParamDeconstruction(variables: Variable[] | undefined, requestBody: string | undefined) {

--- a/lib/next-binding/src/lib/templates/source/controller/method/requestRouteTemplate.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/requestRouteTemplate.ts
@@ -4,7 +4,7 @@ import {
   pascalCase,
   ResourceDescriptor, RestData,
   typescript
-} from 'common';
+} from '@intrig/common';
 import * as path from "path";
 
 export async function requestRouteTemplate(requestUrl: string, paths: ResourceDescriptor<RestData>[], _path: string) {

--- a/lib/next-binding/src/lib/templates/source/controller/method/serverIndex.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/serverIndex.template.ts
@@ -1,7 +1,7 @@
 import {
   camelCase, ResourceDescriptor, RestData,
   typescript
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path'
 import * as _ from "lodash";
 

--- a/lib/next-binding/src/lib/templates/source/type/typeTemplate.ts
+++ b/lib/next-binding/src/lib/templates/source/type/typeTemplate.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3_1 } from 'openapi-types';
-import { jsonLiteral, typescript } from 'common';
+import { jsonLiteral, typescript } from '@intrig/common';
 import * as path from 'path'
 
 export interface TypeTemplateParams {

--- a/lib/next-binding/src/lib/templates/swcrc.template.ts
+++ b/lib/next-binding/src/lib/templates/swcrc.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 
 export function swcrcTemplate(_path: string) {

--- a/lib/next-binding/src/lib/templates/tsconfig.template.ts
+++ b/lib/next-binding/src/lib/templates/tsconfig.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 
 export function tsConfigTemplate(_path: string) {

--- a/lib/openapi-source/src/lib/openapi.service.ts
+++ b/lib/openapi-source/src/lib/openapi.service.ts
@@ -1,5 +1,5 @@
 import {Injectable, Logger} from '@nestjs/common';
-import type {IIntrigSourceConfig, RestOptions} from 'common'
+import type {IIntrigSourceConfig, RestOptions} from '@intrig/common'
 import * as crypto from 'crypto';
 import {
   camelCase,
@@ -10,7 +10,7 @@ import {
   SpecManagementService,
   SyncEventContext,
   WithStatus
-} from 'common'
+} from '@intrig/common'
 import {lastValueFrom} from "rxjs";
 import {HttpService} from "@nestjs/axios";
 import {load as yamlLoad} from "js-yaml";

--- a/lib/openapi-source/src/lib/util/extractRequestsFromSpec.ts
+++ b/lib/openapi-source/src/lib/util/extractRequestsFromSpec.ts
@@ -1,7 +1,7 @@
 // import {deref, IntrigSourceConfig, isRef, RequestProperties} from "@intrig/cli-common";
 import {OpenAPIV3_1} from "openapi-types";
 import {deref, isRef} from "./ref-management";
-import {RestData} from "common";
+import {RestData} from "@intrig/common";
 
 export function extractRequestsFromSpec(spec: OpenAPIV3_1.Document) {
   const requests: RestData[] = [];

--- a/lib/openapi-source/src/lib/util/extractSchemas.ts
+++ b/lib/openapi-source/src/lib/util/extractSchemas.ts
@@ -1,5 +1,5 @@
 import {OpenAPIV3_1} from "openapi-types";
-import {Schema} from "common";
+import {Schema} from "@intrig/common";
 
 export function extractSchemas(spec: OpenAPIV3_1.Document): Schema[] {
   return Object.entries(spec.components?.schemas ?? {}).map(([name, schema]) => ({

--- a/lib/openapi-source/src/lib/util/normalize.ts
+++ b/lib/openapi-source/src/lib/util/normalize.ts
@@ -1,6 +1,6 @@
 import {OpenAPIV3, OpenAPIV3_1} from "openapi-types";
 import {produce} from 'immer'
-import {pascalCase, camelCase} from 'common'
+import {pascalCase, camelCase} from '@intrig/common'
 import ReferenceObject = OpenAPIV3.ReferenceObject;
 import ExampleObject = OpenAPIV3_1.ExampleObject;
 import {deref, isRef} from "./ref-management";

--- a/lib/react-binding/src/lib/cli/react-cli.service.ts
+++ b/lib/react-binding/src/lib/cli/react-cli.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {GeneratorCli, PackageManagerService} from "common";
+import {GeneratorCli, PackageManagerService} from "@intrig/common";
 import { PackageJson } from 'nx/src/utils/package-json';
 import {ConfigService} from "@nestjs/config";
 import process from "node:process";

--- a/lib/react-binding/src/lib/plugin.ts
+++ b/lib/react-binding/src/lib/plugin.ts
@@ -1,4 +1,4 @@
-import {Plugin} from "common";
+import {Plugin} from "@intrig/common";
 import {ReactBindingModule} from "./react-binding.module";
 import {ReactBindingService} from "./react-binding.service";
 import {ReactCliModule} from "./cli/react-cli.module";

--- a/lib/react-binding/src/lib/react-binding.service.ts
+++ b/lib/react-binding/src/lib/react-binding.service.ts
@@ -6,7 +6,7 @@ import {
   ResourceDescriptor,
   RestData, RestDocumentation, Schema, SchemaDocumentation,
   SourceManagementService, Tab
-} from "common";
+} from "@intrig/common";
 import {ConfigService} from "@nestjs/config";
 import path from "path";
 import process from "node:process";

--- a/lib/react-binding/src/lib/templates/context.template.ts
+++ b/lib/react-binding/src/lib/templates/context.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function contextTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/docs/async-hook.ts
+++ b/lib/react-binding/src/lib/templates/docs/async-hook.ts
@@ -1,4 +1,4 @@
-import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from 'common'
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from '@intrig/common'
 
 export function asyncFunctionHookDocs(descriptor: ResourceDescriptor<RestData>) {
   const md = mdLiteral('async-hook.md')

--- a/lib/react-binding/src/lib/templates/docs/react-hook.ts
+++ b/lib/react-binding/src/lib/templates/docs/react-hook.ts
@@ -1,4 +1,4 @@
-import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from 'common'
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from '@intrig/common'
 
 export function reactHookDocs(descriptor: ResourceDescriptor<RestData>) {
   const md = mdLiteral('react-hook.md')

--- a/lib/react-binding/src/lib/templates/docs/sse-hook.ts
+++ b/lib/react-binding/src/lib/templates/docs/sse-hook.ts
@@ -1,4 +1,4 @@
-import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from "common";
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from "@intrig/common";
 
 export function sseHookDocs(descriptor: ResourceDescriptor<RestData>) {
   const md = mdLiteral('sse-hook.md')

--- a/lib/react-binding/src/lib/templates/extra.template.ts
+++ b/lib/react-binding/src/lib/templates/extra.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function extraTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/index.template.ts
+++ b/lib/react-binding/src/lib/templates/index.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function indexTemplate(_path: string){

--- a/lib/react-binding/src/lib/templates/intrigMiddleware.template.ts
+++ b/lib/react-binding/src/lib/templates/intrigMiddleware.template.ts
@@ -1,4 +1,4 @@
-import { typescript } from 'common';
+import { typescript } from '@intrig/common';
 import * as path from 'path'
 
 export function intrigMiddlewareTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/logger.template.ts
+++ b/lib/react-binding/src/lib/templates/logger.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function loggerTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/media-type-utils.template.ts
+++ b/lib/react-binding/src/lib/templates/media-type-utils.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from "path";
 
 export function mediaTypeUtilsTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/network-state.template.ts
+++ b/lib/react-binding/src/lib/templates/network-state.template.ts
@@ -1,4 +1,4 @@
-import {typescript} from "common";
+import {typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function networkStateTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/packageJson.template.ts
+++ b/lib/react-binding/src/lib/templates/packageJson.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 import * as fsx from "fs-extra";
 

--- a/lib/react-binding/src/lib/templates/provider.template.ts
+++ b/lib/react-binding/src/lib/templates/provider.template.ts
@@ -1,4 +1,4 @@
-import {IntrigSourceConfig, typescript} from "common";
+import {IntrigSourceConfig, typescript} from "@intrig/common";
 import * as path from 'path'
 
 export function providerTemplate(_path: string, apisToSync: IntrigSourceConfig[]) {

--- a/lib/react-binding/src/lib/templates/source/controller/method/asyncFunctionHook.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/asyncFunctionHook.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase, ResourceDescriptor, RestData,
   typescript,
   Variable
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path';
 
 function extractAsyncHookShape(response: string | undefined, requestBody: string | undefined, imports: Set<string>) {

--- a/lib/react-binding/src/lib/templates/source/controller/method/clientIndex.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/clientIndex.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase,
   ResourceDescriptor, RestData,
   typescript
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path'
 
 export async function clientIndexTemplate(descriptors: ResourceDescriptor<RestData>[], _path: string) {

--- a/lib/react-binding/src/lib/templates/source/controller/method/download.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/download.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase,
   ResourceDescriptor, RestData,
   typescript, Variable
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path';
 
 function extractHookShapeAndOptionsShape(response: string | undefined, requestBody: string | undefined, imports: Set<string>) {

--- a/lib/react-binding/src/lib/templates/source/controller/method/params.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/params.template.ts
@@ -5,7 +5,7 @@ import {
   ResourceDescriptor,
   RestData,
   typescript
-} from "common";
+} from "@intrig/common";
 import * as path from "path";
 
 export async function paramsTemplate({source, data: {paths, operationId, variables}}: ResourceDescriptor<RestData>, _path: string) {

--- a/lib/react-binding/src/lib/templates/source/controller/method/requestHook.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/requestHook.template.ts
@@ -4,7 +4,7 @@ import {
   pascalCase, ResourceDescriptor, RestData,
   typescript,
   Variable
-} from 'common';
+} from '@intrig/common';
 import * as path from 'path';
 
 function extractHookShapeAndOptionsShape(response: string | undefined, requestBody: string | undefined, imports: Set<string>) {

--- a/lib/react-binding/src/lib/templates/source/type/typeTemplate.ts
+++ b/lib/react-binding/src/lib/templates/source/type/typeTemplate.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3_1 } from 'openapi-types';
-import { jsonLiteral, typescript } from 'common';
+import { jsonLiteral, typescript } from '@intrig/common';
 import * as path from 'path'
 
 export interface SchemaConversionResult {

--- a/lib/react-binding/src/lib/templates/swcrc.template.ts
+++ b/lib/react-binding/src/lib/templates/swcrc.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 
 export function swcrcTemplate(_path: string) {

--- a/lib/react-binding/src/lib/templates/tsconfig.template.ts
+++ b/lib/react-binding/src/lib/templates/tsconfig.template.ts
@@ -1,4 +1,4 @@
-import {jsonLiteral} from "common";
+import {jsonLiteral} from "@intrig/common";
 import * as path from "path";
 
 export function tsConfigTemplate(_path: string) {

--- a/nx.json
+++ b/nx.json
@@ -29,7 +29,7 @@
           "watchDepsName": "watch-deps"
         }
       },
-      "exclude": ["lib/openapi-source/*", "lib/shared/*", "lib/common/*"]
+      "exclude": ["lib/openapi-source/*", "lib/shared/*"]
     },
     {
       "plugin": "@nx/webpack/plugin",
@@ -56,7 +56,7 @@
     },
     {
       "plugin": "@nx/js/typescript",
-      "include": ["lib/openapi-source/*", "lib/shared/*", "lib/common/*"],
+      "include": ["lib/openapi-source/*", "lib/shared/*"],
       "options": {
         "typecheck": {
           "targetName": "typecheck"
@@ -114,6 +114,7 @@
       "lib/react-client",
       "lib/next-binding",
       "lib/react-binding",
+      "lib/common",
       "@intrig/registry"
     ],
     "npmPackages": [
@@ -136,6 +137,10 @@
       {
         "packageRoot": "dist/lib/react-binding",
         "packageName": "@intrig/react-binding"
+      },
+      {
+        "packageRoot": "dist/lib/common",
+        "packageName": "@intrig/common"
       }
     ]
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,8 @@
     "declaration": true,
     "paths": {
       "@intrig/next-binding": ["./lib/next-binding/src/index.ts"],
-      "@intrig/react-binding": ["./lib/react-binding/src/index.ts"]
+      "@intrig/react-binding": ["./lib/react-binding/src/index.ts"],
+      "@intrig/common": ["./lib/common/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- make `lib/common` buildable and publishable
- rename package to `@intrig/common`
- add Nx build and publish targets
- update import path references
- register alias and release config for the new package

## Testing
- `npx tsc -p lib/common/tsconfig.lib.json --noEmit`
- `npx nx build @intrig/common` *(fails: No existing Nx Cloud client and failed to download new version)*

------
https://chatgpt.com/codex/tasks/task_e_68694a2229a88329bc04be365f7a9d78