### PR TITLE
refactor: simplify `BinaryDataSchema` and enhance response type handl…

### DIFF
--- a/lib/react-binding/src/lib/templates/source/controller/method/download.template.ts
+++ b/lib/react-binding/src/lib/templates/source/controller/method/download.template.ts
@@ -137,6 +137,16 @@ export async function reactDownloadHookTemplate({source,
 
   const finalRequestBodyBlock = requestBody ? `,data: encode(data, "${contentType}", requestBodySchema)` : ''
 
+  function responseTypePart() {
+    switch (responseType) {
+      case "application/octet-stream":
+        return `responseType: 'blob', adapter: 'fetch',`;
+      case "text/event-stream":
+        return `responseType: 'stream', adapter: 'fetch',`;
+    }
+    return ''
+  }
+
   return ts`
     ${[...imports].join('\n')}
 
@@ -213,7 +223,7 @@ export async function reactDownloadHookTemplate({source,
             key: \`${"${source}: ${operation}"}\`,
             source: '${source}'
             ${requestBody ? finalRequestBodyBlock : ''},
-            ${responseType === "text/event-stream" ? `responseType: 'stream', adapter: 'fetch',` : ''}
+            ${(responseTypePart())}
           })
           return successfulDispatch();
       }, [dispatch])

--- a/lib/react-binding/src/lib/templates/type-utils.template.ts
+++ b/lib/react-binding/src/lib/templates/type-utils.template.ts
@@ -6,23 +6,8 @@ export function typeUtilsTemplate(_path: string) {
 
   return ts`import { z } from 'zod';
 
-export type BinaryData = Blob | ArrayBuffer | Uint8Array;
-
-export const BinaryDataSchema = z.union([
-  // Blob in browsers
-  z.instanceof(Blob).optional(), // optional here so union below still validates if Blob is absent in Node
-  // Raw buffers
-  z.instanceof(ArrayBuffer),
-  z.custom<Uint8Array>((v) => v instanceof Uint8Array, { message: 'Expected Uint8Array' }),
-]).transform((v) => {
-  // Normalize to Blob if possible (nice for downloads in browser)
-  if (typeof Blob !== 'undefined') {
-    if (v instanceof Blob) return v;
-    if (v instanceof ArrayBuffer) return new Blob([v]);
-    if (v instanceof Uint8Array) return new Blob([v.buffer]);
-  }
-  return v;
-});
+export type BinaryData = Blob;
+export const BinaryDataSchema: z.ZodType<BinaryData> = z.instanceof(Blob);
 
 // Base64 helpers (browser + Node compatible; no Buffer required)
 export function base64ToUint8Array(b64: string): Uint8Array {


### PR DESCRIPTION
…ing in templates

- Replaced complex `BinaryDataSchema` with a simplified `z.instanceof(Blob)` implementation.
- Added a helper function `responseTypePart` to streamline response type and adapter logic in `download.template.ts`.