### PR TITLE
feat: add async and SSE hook templates with documentation support

### DIFF
--- a/lib/next-binding/src/lib/templates/docs/async-hook.ts
+++ b/lib/next-binding/src/lib/templates/docs/async-hook.ts
@@ -1,0 +1,77 @@
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from 'common'
+
+export function nextAsyncFunctionHookDocs(descriptor: ResourceDescriptor<RestData>) {
+  const md = mdLiteral('async-hook.md')
+
+  const requestBody = descriptor.data.requestBody ? camelCase(descriptor.data.requestBody) : undefined
+  const params = descriptor.data.variables?.filter(a => a.in.toUpperCase() ===  'PATH')?.length ? 'params' : undefined
+
+  return md`
+  
+> Intrig generated async hooks are intended to use for the rapid usecases like validations. This effectively bypasses the network-state management.
+> The async hooks follow the tuple-based API pattern as React's built-in state hooks (e.g. useState).
+
+## Imports
+
+#### Import the hook to the component.
+${"```ts"}
+import { use${pascalCase(descriptor.name)}Async } from '@intrig/next/${descriptor.path}/client';
+${"```"}
+
+#### Use hook inside the component.
+
+${"```tsx"}
+const [${camelCase(descriptor.name)}, abort${pascalCase(descriptor.name)}] = use${pascalCase(descriptor.name)}Async();
+${"```"}
+
+#### Execute data fetching / calling.
+
+${"```tsx"}
+const fn = useCallback(async () => {
+  let ${camelCase(descriptor.name)}Data = await ${camelCase(descriptor.name)}(${[requestBody, params ?? '{}'].filter(Boolean).join(', ')});
+  //TODO do something with the ${camelCase(descriptor.name)}Data.
+  return ${camelCase(descriptor.name)}Data; 
+}, [${[requestBody, params].filter(Boolean).join(', ')}/* Dependencies */])
+
+${"```"}
+
+## Full example
+
+<details>
+<summary>Implementation</summary>
+
+${"```tsx"}
+import { use${pascalCase(descriptor.name)}Async } from '@intrig/next/${descriptor.path}/client';
+${requestBody ? `import { ${pascalCase(requestBody)} } from '@intrig/next/${descriptor.source}/components/schemas/${pascalCase(requestBody)}';` : ''}
+${params ? `import { ${pascalCase(params)}Params } from '@intrig/next/${descriptor.path}/${pascalCase(descriptor.name)}.params';` : ''}
+import { useCallback } from 'react';
+
+${requestBody || params ? `
+interface MyComponentProps {
+  ${requestBody ? `${camelCase(requestBody)}: ${pascalCase(requestBody)};` : ''}
+  ${params ? `${camelCase(params)}Params: ${pascalCase(params)}Params;` : ''}
+}
+` : ''}
+
+function MyComponent(${requestBody || params ? 'props: MyComponentProps' : ''}) {
+const [${camelCase(descriptor.name)}, abort${pascalCase(descriptor.name)}] = use${pascalCase(descriptor.name)}Async();
+
+const fn = useCallback(async (${[requestBody, params].filter(Boolean).join(', ')}) => {
+  return await ${camelCase(descriptor.name)}(${[requestBody, params].filter(Boolean).join(', ')});
+}, [/* Dependencies */])
+
+//use fn where remote callback is needed.
+return <>
+  <button onClick={() => fn(${[requestBody, params].filter(Boolean).map(a => `props.${a}`).join(', ')})}>Call remote</button>  
+</>
+}
+ 
+${"```"}
+</details>
+
+<hint>
+//TODO improve with usecases
+</hint>
+  
+  `
+}

--- a/lib/next-binding/src/lib/templates/docs/sse-hook.ts
+++ b/lib/next-binding/src/lib/templates/docs/sse-hook.ts
@@ -1,0 +1,163 @@
+import {camelCase, mdLiteral, pascalCase, ResourceDescriptor, RestData} from "common";
+
+export function nextSseHookDocs(descriptor: ResourceDescriptor<RestData>) {
+  const md = mdLiteral('sse-hook.md')
+
+  const requestBody = descriptor.data.requestBody ? camelCase(descriptor.data.requestBody) : undefined
+  const params = descriptor.data.variables?.filter(a => a.in.toUpperCase() ===  'PATH')?.length ? 'params' : undefined
+
+  return md`
+> Intrig-generated hooks are intended for backend data integration. They follow the same tuple-based API pattern as React's built-in state hooks (e.g. useState). 
+
+## Imports
+
+#### Import the hook to the component.
+${"```ts"}
+import { use${pascalCase(descriptor.name)} } from '@intrig/next/${descriptor.path}/client';
+${"```"}
+
+#### Import the utility methods.
+${"```ts"}
+import { isSuccess } from '@intrig/next';
+${"```"}
+
+#### Use hook inside the component.
+
+${"```tsx"}
+const [${camelCase(descriptor.name)}Resp, ${camelCase(descriptor.name)}, clear${pascalCase(descriptor.name)}] = use${pascalCase(descriptor.name)}();
+${"```"}
+
+### Usage
+
+#### Execute data fetching.
+
+${"```tsx"}
+useEffect(() => {
+  ${camelCase(descriptor.name)}(${[requestBody, params ?? '{}'].filter(Boolean).join(', ')}); 
+}, [${[requestBody, params].filter(Boolean).join(', ')}/* Dependencies */])  
+${"```"}
+
+#### Extract data from the response.
+\`SSE\` hooks are a special kind of hook that delivers intermediate data updates as they are received.
+
+##### Minimal example.
+${"```tsx"}
+const ${camelCase(descriptor.name)} = isPending(${camelCase(descriptor.name)}Resp) ? ${camelCase(descriptor.name)}Resp.data : null;
+${"```"}
+
+### Full example.
+
+#### Short format.
+You can pass the request body and params as props to the hook for initial data binding. This will create the data to be tightly coupled
+with the component lifecycle.
+
+> Usually the SSE-hooks are combined with a collector mechanism to get the complete message. 
+
+<details>
+<summary>Implementation</summary>
+
+${"```tsx"}
+import { use${pascalCase(descriptor.name)} } from '@intrig/next/${descriptor.path}/client';
+import { isSuccess, isPending, isError } from '@intrig/next';
+${requestBody ? `import { ${pascalCase(requestBody)} } from '@intrig/next/${descriptor.source}/components/schemas/${pascalCase(requestBody)}';` : ''}
+${params ? `import { ${pascalCase(params)}Params } from '@intrig/next/${descriptor.path}/${pascalCase(descriptor.name)}.params';` : ''}
+import { useState, useEffect } from 'react';
+import { LoadingIndicator, ErrorDisplay } from '@/components/ui'; //import from your project.
+import {flushSync} from "react-dom";
+
+${requestBody || params ? `
+interface MyComponentProps {
+  ${requestBody ? `${camelCase(requestBody)}: ${pascalCase(requestBody)};` : ''}
+  ${params ? `${camelCase(params)}Params: ${pascalCase(params)}Params;` : ''}
+}
+` : ''}
+
+function MyComponent(${requestBody || params ? 'props: MyComponentProps' : ''}) { 
+const [${camelCase(descriptor.name)}Resp] = use${pascalCase(descriptor.name)}({
+  fetchOnMount: true,
+  clearOnUnmount: true,
+  ${requestBody ? `body: props.${camelCase(requestBody)},` : ''}
+  ${params ? `params: props.${camelCase(params)},` : 'params: {}'}
+});
+
+let [data, setData] = useState<${pascalCase(descriptor.name)}[]>([]);
+
+useEffect(() => {
+  if (isPending(${camelCase(descriptor.name)}Resp)) {
+    flushSync(() => {                                                     //Sometimes react tends to skip intermediate renders for the performance. Use flushSync if you need to keep track of messages. 
+      setData(data => [...data, ${camelCase(descriptor.name)}Resp.data]);
+    })
+  }
+}, [${camelCase(descriptor.name)}Resp])
+
+if (isPending(${camelCase(descriptor.name)}Resp)) {
+  return <>{data.map(a => <>{JSON.stringify(a)}</>)}</>
+}
+
+if (isError(${camelCase(descriptor.name)}Resp)) {
+  return <ErrorDisplay error={${camelCase(descriptor.name)}Resp.error}/> //TODO add your error view here.
+}
+
+return <> 
+  Completed: {JSON.stringify(data)}  
+</>
+}
+${"```"}
+</details>
+
+#### Controlled format.
+If you need more control over the data binding, where the data control is outside of the component lifecycle, 
+you can use the actions provided by the hook.
+
+<details>
+<summary>Implementation</summary>
+
+${"```tsx"}
+import { use${pascalCase(descriptor.name)} } from '@intrig/next/${descriptor.path}/client';
+import { isSuccess } from '@intrig/next';
+${requestBody ? `import { ${pascalCase(requestBody)} } from '@intrig/next/${descriptor.source}/components/schemas/${pascalCase(requestBody)}';` : ''}
+${params ? `import { ${pascalCase(params)}Params } from '@intrig/next/${descriptor.path}/${pascalCase(descriptor.name)}.params';` : ''}
+import {flushSync} from "react-dom";
+
+${requestBody || params ? `
+interface MyComponentProps {
+  ${requestBody ? `${camelCase(requestBody)}: ${pascalCase(requestBody)};` : ''}
+  ${params ? `${camelCase(params)}Params: ${pascalCase(params)}Params;` : ''}
+}
+` : ''}
+
+function MyComponent() {
+const [${camelCase(descriptor.name)}Resp, ${camelCase(descriptor.name)}, clear${pascalCase(descriptor.name)}] = use${pascalCase(descriptor.name)}();
+
+useEffect(() => { 
+  ${camelCase(descriptor.name)}(${requestBody ? `${camelCase(requestBody)},` : ''} ${params ? `${camelCase(params)},` : '{}'}) //Call the fetch function. 
+  return clear${pascalCase(descriptor.name)}; //Clear the data on unmount.
+}, [])
+
+let [data, setData] = useState<${pascalCase(descriptor.name)}[]>([]);
+
+useEffect(() => {
+  if (isPending(${camelCase(descriptor.name)}Resp)) {
+    flushSync(() => {                                                     //Sometimes react tends to skip intermediate renders for the performance. Use flushSync if you need to keep track of messages. 
+      setData(data => [...data, ${camelCase(descriptor.name)}Resp.data]);
+    })
+  }
+}, [${camelCase(descriptor.name)}Resp])
+
+if (isPending(${camelCase(descriptor.name)}Resp)) {
+  return <>{data.map(a => <>{JSON.stringify(a)}</>)}</>
+}
+
+if (isError(${camelCase(descriptor.name)}Resp)) {
+  return <ErrorDisplay error={${camelCase(descriptor.name)}Resp.error}/> //TODO add your error view here.
+}
+
+return <> 
+  Completed: {JSON.stringify(data)}  
+</>
+}
+${"```"}
+</details>
+
+  `
+}

--- a/lib/next-binding/src/lib/templates/source/controller/method/asyncFunctionHook.template.ts
+++ b/lib/next-binding/src/lib/templates/source/controller/method/asyncFunctionHook.template.ts
@@ -1,0 +1,196 @@
+import {
+  camelCase,
+  generatePostfix,
+  GeneratorContext,
+  pascalCase, ResourceDescriptor, RestData,
+  typescript,
+  Variable
+} from 'common';
+import * as path from 'path';
+
+function extractAsyncHookShape(response: string | undefined, requestBody: string | undefined, imports: Set<string>) {
+  if (response) {
+    if (requestBody) {
+      imports.add(`import { BinaryFunctionAsyncHook } from "@intrig/next"`);
+      return `BinaryFunctionAsyncHook<Params, RequestBody, Response, _ErrorType>`;
+    } else {
+      imports.add(`import { UnaryFunctionAsyncHook } from "@intrig/next"`);
+      return `UnaryFunctionAsyncHook<Params, Response, _ErrorType>`;
+    }
+  } else {
+    if (requestBody) {
+      imports.add(`import { BinaryProduceAsyncHook } from "@intrig/next"`);
+      return `BinaryProduceAsyncHook<Params, RequestBody, _ErrorType>`;
+    } else {
+      imports.add(`import { UnaryProduceAsyncHook } from "@intrig/next"`);
+      return `UnaryProduceAsyncHook<Params, _ErrorType>`;
+    }
+  }
+}
+
+function extractErrorParams(errorTypes: string[]) {
+  switch (errorTypes.length) {
+    case 0:
+      return `
+      export type _ErrorType = any
+      const errorSchema = z.any()`
+    case 1:
+      return `
+      export type _ErrorType = ${errorTypes[0]}
+      const errorSchema = ${errorTypes[0]}Schema`
+    default:
+      return `
+      export type _ErrorType = ${errorTypes.join(' | ')}
+      const errorSchema = z.union([${errorTypes.map(a => `${a}Schema`).join(', ')}])`
+  }
+}
+
+function extractParamDeconstruction(variables: Variable[], requestBody?: string) {
+  const isParamMandatory = variables?.some(a => a.in === 'path') || false;
+
+  if (requestBody) {
+    if (isParamMandatory) {
+      return {
+        paramExpression: 'data, p',
+        paramType: 'data: RequestBody, params: Params'
+      }
+    } else {
+      return {
+        paramExpression: 'data, p = {}',
+        paramType: 'data: RequestBody, params?: Params'
+      }
+    }
+  } else {
+    if (isParamMandatory) {
+      return {
+        paramExpression: 'p',
+        paramType: 'params: Params'
+      }
+    } else {
+      return {
+        paramExpression: 'p = {}',
+        paramType: 'params?: Params'
+      }
+    }
+  }
+}
+
+
+export async function nextAsyncFunctionHookTemplate(
+  {source,
+    data: {
+      paths,
+      operationId,
+      response,
+      requestUrl,
+      variables,
+      requestBody,
+      contentType,
+      responseType,
+      errorResponses,
+      method
+    }
+  }: ResourceDescriptor<RestData>, _path: string, ctx: GeneratorContext) {
+  const postfix = ctx.potentiallyConflictingDescriptors.includes(operationId) ? generatePostfix(contentType, responseType) : ''
+  const ts = typescript(path.resolve(_path, 'src', source, ...paths, camelCase(operationId), `use${pascalCase(operationId)}Async${postfix}.ts`));
+
+  const modifiedRequestUrl = `${requestUrl?.replace(/\{/g, "${")}`;
+  const imports = new Set<string>();
+
+  // Basic imports
+  imports.add(`import { z } from 'zod'`);
+  imports.add(`import { useCallback } from 'react'`);
+  imports.add(`import { useTransientCall, encode, isError, isSuccess } from '@intrig/next'`);
+
+  // Hook signature type
+  const hookShape = extractAsyncHookShape(response, requestBody, imports);
+
+  // Add body/response param imports
+  if (requestBody) {
+    imports.add(`import { ${requestBody} as RequestBody, ${requestBody}Schema as requestBodySchema } from "@intrig/next/${source}/components/schemas/${requestBody}"`);
+  }
+
+  if (response) {
+    imports.add(`import { ${response} as Response, ${response}Schema as schema } from "@intrig/next/${source}/components/schemas/${response}"`);
+  }
+
+  imports.add(`import { ${pascalCase(operationId)}Params as Params } from './${pascalCase(operationId)}.params'`);
+
+  // Error types
+  const errorTypes = [...new Set(Object.values(errorResponses ?? {}).map((a) => a.response))];
+  errorTypes.forEach((ref) => imports.add(`import { ${ref}, ${ref}Schema } from "@intrig/next/${source}/components/schemas/${ref}"`));
+
+  // Error schema block
+  const errorSchemaBlock = extractErrorParams(errorTypes.map((a) => a as string));
+
+  // Param deconstruction
+  const { paramExpression, paramType } = extractParamDeconstruction(variables ?? [], requestBody);
+
+  const paramExplode = [
+    ...(variables?.filter((a) => a.in === 'path').map((a) => a.name) ?? []),
+    '...params',
+  ].join(',');
+
+  const finalRequestBodyBlock = requestBody ? `, data: encode(data, "${contentType}", requestBodySchema)` : '';
+
+  function responseTypePart() {
+    switch (responseType) {
+      case "application/octet-stream":
+        return `responseType: 'blob', adapter: 'fetch',`;
+      case "text/event-stream":
+        return `responseType: 'stream', adapter: 'fetch',`;
+    }
+    return ''
+  }
+
+  return ts`
+${[...imports].join('\n')}
+
+${!response ? `
+type Response = any;
+const schema = z.any();
+` : ''}
+
+${errorSchemaBlock}
+
+const operation = "${method.toUpperCase()} ${requestUrl}| ${contentType} -> ${responseType}";
+const source = "${source}";
+
+function use${pascalCase(operationId)}AsyncHook(): [(${paramType}) => Promise<Response>, () => void] {
+  const [call, abort] = useTransientCall<Response, _ErrorType>({
+    schema,
+    errorSchema
+  });
+
+  const doExecute = useCallback<(${paramType}) => Promise<Response>>(async (${paramExpression}) => {
+    let { ${paramExplode} } = p;
+
+    ${requestBody ? `
+    const validationResult = requestBodySchema.safeParse(data);
+    if (!validationResult.success) {
+      return Promise.reject(validationResult.error);
+    }
+    ` : ''}
+
+    return await call({
+      method: '${method}',
+      url: \`${modifiedRequestUrl}\`,
+      headers: {
+        ${contentType ? `"Content-Type": "${contentType}",` : ''}
+      },
+      params,
+      key: \`${"${source}: ${operation}"}\`,
+      source: '${source}'
+      ${requestBody ? finalRequestBodyBlock : ''},
+      ${(responseTypePart())}
+    });
+  }, [call]);
+
+  return [doExecute, abort];
+}
+
+use${pascalCase(operationId)}AsyncHook.key = \`${"${source}: ${operation}"}\`;
+
+export const use${pascalCase(operationId)}Async: ${hookShape} = use${pascalCase(operationId)}AsyncHook;
+  `;
+}

--- a/lib/next-binding/src/lib/templates/type-utils.template.ts
+++ b/lib/next-binding/src/lib/templates/type-utils.template.ts
@@ -1,0 +1,28 @@
+import {typescript} from "common";
+import path from "path";
+
+export function typeUtilsTemplate(_path: string) {
+  const ts = typescript(path.resolve(_path, 'src', 'type-utils.ts'))
+
+  return ts`import { z } from 'zod';
+
+export type BinaryData = Blob;
+export const BinaryDataSchema: z.ZodType<BinaryData> = z.instanceof(Blob);
+
+// Base64 helpers (browser + Node compatible; no Buffer required)
+export function base64ToUint8Array(b64: string): Uint8Array {
+  if (typeof atob === 'function') {
+    // Browser
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes;
+  } else {
+    // Node
+    const buf = Buffer.from(b64, 'base64');
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+}
+
+  `
+}


### PR DESCRIPTION
- Introduced `nextAsyncFunctionHookDocs` and `nextSseHookDocs` templates for generating documentation for async and SSE hooks.
- Added `asyncFunctionHook.template.ts` for creating async function hooks with type safety and improved param deconstruction.
- Enhanced `IntrigNextBindingService` with utility functions and logging for better generation context management.
- Added `type-utils.template.ts` for shared utilities like base64 and binary data handling.
- Updated hook generation to handle scenarios like binary responses and SSE streams more effectively.